### PR TITLE
Can Range for Elevator

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Hackbots code for the 2025 FRC Reefscape game.
 | Coral 2 | 56 |
 | Algae Pivot | 57 |
 | Algae Rollers | 60 |
+| CAN Range | 6 |
 
 
 ## Driver Controls

--- a/ThriftyTest/src/main/java/frc/robot/Constants.java
+++ b/ThriftyTest/src/main/java/frc/robot/Constants.java
@@ -188,20 +188,23 @@ public class Constants {
         public static final int numWaypoints = 5;
     }
 
+    public static final class CanRangeConstants {
+        public static final int k_canRangeId = 5;
+
+        public static final double k_timeout = 1.0; // seconds
+
+        public static final CANrangeConfiguration k_canRangeConfig = new CANrangeConfiguration();
+        // .withFovParams(null)
+        // .withProximityParams(null)
+        // .withToFParams(null);
+
+        public static final int k_filterWindow = 5; // 5 measurements
+    }
+
     public static final class ElevatorConstants {
         public static final int leftMotorID = 51;
         public static final int rightMotorID = 52;
         public static final int encoderPort = 53;
-        public static final int k_canRangeId = 5;
-
-        public static final CANrangeConfiguration k_canRangeConfig = new CANrangeConfiguration();
-            // .withFovParams(null)
-            // .withProximityParams(null)
-            // .withToFParams(null);
-
-        public static final double k_timeout = 1.0; // seconds
-
-        public static final int k_filterWindow = 5; // 5 measurements
 
         public static final boolean invertRightMotor = true;
 

--- a/ThriftyTest/src/main/java/frc/robot/Constants.java
+++ b/ThriftyTest/src/main/java/frc/robot/Constants.java
@@ -189,7 +189,7 @@ public class Constants {
     }
 
     public static final class CanRangeConstants {
-        public static final int k_canRangeId = 5;
+        public static final int k_canRangeId = 6;
 
         public static final double k_timeout = 1.0; // seconds
 

--- a/ThriftyTest/src/main/java/frc/robot/Constants.java
+++ b/ThriftyTest/src/main/java/frc/robot/Constants.java
@@ -75,7 +75,7 @@ public class Constants {
     }
 
     public static class RobotConstants {
-        public static final double globalCanTimeout = 20;
+        public static final Time globalCanTimeout = Milliseconds.of(20); // 20 milliseconds
 
         public static final double k_robotX = Units.inchesToMeters(30.0);
         public static final double k_robotY = Units.inchesToMeters(30.0);

--- a/ThriftyTest/src/main/java/frc/robot/Constants.java
+++ b/ThriftyTest/src/main/java/frc/robot/Constants.java
@@ -191,8 +191,6 @@ public class Constants {
     public static final class CanRangeConstants {
         public static final int k_canRangeId = 6;
 
-        public static final double k_timeout = 1.0; // seconds
-
         public static final CANrangeConfiguration k_canRangeConfig = new CANrangeConfiguration();
         // .withFovParams(null)
         // .withProximityParams(null)

--- a/ThriftyTest/src/main/java/frc/robot/subsystems/AlgaeRollers.java
+++ b/ThriftyTest/src/main/java/frc/robot/subsystems/AlgaeRollers.java
@@ -9,6 +9,8 @@ import com.ctre.phoenix6.signals.NeutralModeValue;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
+import static edu.wpi.first.units.Units.Seconds;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,8 +39,8 @@ public class AlgaeRollers extends SubsystemBase implements AutoCloseable{
         currentConfigs.withSupplyCurrentLimit(Constants.AlgaeRollerConstants.algaeRollerCurrentLimit);
         currentConfigs.SupplyCurrentLimitEnable = true;
         TalonFXConfigurator configurator = algaeRollerMotor.getConfigurator();
-        configurator.apply(currentConfigs, Constants.RobotConstants.globalCanTimeout);
-        configurator.apply(motorOutput, Constants.RobotConstants.globalCanTimeout);
+        configurator.apply(currentConfigs, Constants.RobotConstants.globalCanTimeout.in(Seconds));
+        configurator.apply(motorOutput, Constants.RobotConstants.globalCanTimeout.in(Seconds));
     }
 
     private void setMotor(double voltage) {

--- a/ThriftyTest/src/main/java/frc/robot/subsystems/Climber.java
+++ b/ThriftyTest/src/main/java/frc/robot/subsystems/Climber.java
@@ -1,7 +1,9 @@
 package frc.robot.subsystems;
 
-import frc.robot.Constants;
-import frc.robot.Constants.ClimberConstants;
+import static edu.wpi.first.units.Units.Seconds;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.MotorOutputConfigs;
@@ -11,9 +13,9 @@ import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants;
+import frc.robot.Constants.ClimberConstants;
 
 public class Climber extends SubsystemBase implements AutoCloseable {
     private final Logger m_logger = LoggerFactory.getLogger(Climber.class);
@@ -38,11 +40,11 @@ public class Climber extends SubsystemBase implements AutoCloseable {
         currentConfigs.withSupplyCurrentLimit(Constants.ClimberConstants.climberCurrentLimit);
         currentConfigs.SupplyCurrentLimitEnable = true;
         TalonFXConfigurator configurator = rightClimbMotor.getConfigurator();
-        configurator.apply(currentConfigs, Constants.RobotConstants.globalCanTimeout);
-        configurator.apply(motorOutput, Constants.RobotConstants.globalCanTimeout);
+        configurator.apply(currentConfigs, Constants.RobotConstants.globalCanTimeout.in(Seconds));
+        configurator.apply(motorOutput, Constants.RobotConstants.globalCanTimeout.in(Seconds));
         configurator = leftClimbMotor.getConfigurator();
-        configurator.apply(currentConfigs, Constants.RobotConstants.globalCanTimeout);
-        configurator.apply(motorOutput, Constants.RobotConstants.globalCanTimeout);
+        configurator.apply(currentConfigs, Constants.RobotConstants.globalCanTimeout.in(Seconds));
+        configurator.apply(motorOutput, Constants.RobotConstants.globalCanTimeout.in(Seconds));
 
         leftClimbMotor.setControl(new Follower(rightClimbMotor.getDeviceID(), true));
     }

--- a/ThriftyTest/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/ThriftyTest/src/main/java/frc/robot/subsystems/Elevator.java
@@ -31,6 +31,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants.CanRangeConstants;
 import frc.robot.Constants.ElevatorConstants;
+import frc.robot.Constants.RobotConstants;
 import frc.robot.stateSpace.StateSpaceController;
 
 public class Elevator extends SubsystemBase {
@@ -112,7 +113,7 @@ public class Elevator extends SubsystemBase {
         m_canrange.clearStickyFaults();
         m_canrange.getConfigurator().apply(
             CanRangeConstants.k_canRangeConfig,
-            CanRangeConstants.k_timeout
+            RobotConstants.globalCanTimeout
         );
     }
 

--- a/ThriftyTest/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/ThriftyTest/src/main/java/frc/robot/subsystems/Elevator.java
@@ -4,6 +4,8 @@
 
 package frc.robot.subsystems;
 
+import static edu.wpi.first.units.Units.Seconds;
+
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.controls.DutyCycleOut;
 import com.ctre.phoenix6.controls.Follower;
@@ -113,7 +115,7 @@ public class Elevator extends SubsystemBase {
         m_canrange.clearStickyFaults();
         m_canrange.getConfigurator().apply(
             CanRangeConstants.k_canRangeConfig,
-            RobotConstants.globalCanTimeout
+            RobotConstants.globalCanTimeout.in(Seconds)
         );
     }
 

--- a/ThriftyTest/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/ThriftyTest/src/main/java/frc/robot/subsystems/Elevator.java
@@ -29,6 +29,7 @@ import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
 import edu.wpi.first.wpilibj.smartdashboard.MechanismRoot2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.CanRangeConstants;
 import frc.robot.Constants.ElevatorConstants;
 import frc.robot.stateSpace.StateSpaceController;
 
@@ -38,9 +39,10 @@ public class Elevator extends SubsystemBase {
 
     private final CANcoder m_cancoder = new CANcoder(ElevatorConstants.encoderPort);
 
-    private final CANrange m_canrange = new CANrange(ElevatorConstants.k_canRangeId);
+    private final CANrange m_canrange = new CANrange(CanRangeConstants.k_canRangeId);
 
-    private final MedianFilter m_filter = new MedianFilter(ElevatorConstants.k_filterWindow);
+    // Although I would love to implement a Kalman Filter for this, that takes too much time!!!
+    private final MedianFilter m_filter = new MedianFilter(CanRangeConstants.k_filterWindow);
 
     private final DigitalInput m_forwardLimiter = new DigitalInput(ElevatorConstants.forwardLimitChannelID);
     private final DigitalInput m_reverseLimiter = new DigitalInput(ElevatorConstants.reverseLimitChannelID);
@@ -69,7 +71,7 @@ public class Elevator extends SubsystemBase {
         configMotor();
         configStateSpace();
         configSim();
-        configLidar();
+        configCanRange();
     }
 
     private void configEncoder() {
@@ -106,9 +108,12 @@ public class Elevator extends SubsystemBase {
         SmartDashboard.putData("Elevator Visualization", m_mechVisual);
     }
 
-    private void configLidar() {
+    private void configCanRange() {
         m_canrange.clearStickyFaults();
-        m_canrange.getConfigurator().apply(ElevatorConstants.k_canRangeConfig, ElevatorConstants.k_timeout);
+        m_canrange.getConfigurator().apply(
+            CanRangeConstants.k_canRangeConfig,
+            CanRangeConstants.k_timeout
+        );
     }
 
     private Vector<N2> getOutput() {


### PR DESCRIPTION
This makes the following changes:
* Instead of an encoder, we use a CANRange to determine the position of the elevator
* This is used inside of code
* Values are filtered via a [`MedianFilter`](https://github.wpilib.org/allwpilib/docs/release/java/edu/wpi/first/math/filter/MedianFilter.html) to get "good" readings.