### PR TITLE
timeout fixes + helpful shell utility

### DIFF
--- a/ThriftyTest/src/main/java/frc/robot/Constants.java
+++ b/ThriftyTest/src/main/java/frc/robot/Constants.java
@@ -281,7 +281,7 @@ public class Constants {
         public static final double k_cameraYaw = Units.degreesToRadians(35.0);
         public static final double k_backCameraYaw = Units.degreesToRadians(45.0);
 
-        public static final String k_logPath = "vision.log";
+        public static final String k_logPath = "logs/vision";
 
         // The camera names
         public static Map<String, Transform3d> cameras = Map.ofEntries(

--- a/ThriftyTest/src/main/java/frc/robot/vision/LogBuilder.java
+++ b/ThriftyTest/src/main/java/frc/robot/vision/LogBuilder.java
@@ -4,19 +4,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 import edu.wpi.first.math.geometry.Pose2d;
+import frc.robot.RobotObserver;
 
 public class LogBuilder {
     private List<TimestampedPoseEstimate> m_estimates;
     private List<VisionLog> m_logs;
-    private Pose2d m_result;
 
     public LogBuilder() {
         m_estimates = new ArrayList<>();
         m_logs = new ArrayList<>();
-    }
-
-    public void setResult(Pose2d result) {
-        m_result = result;
     }
 
     public void addEstimate(TimestampedPoseEstimate estimate) {
@@ -25,11 +21,12 @@ public class LogBuilder {
 
     private void buildLogs() {
         for (TimestampedPoseEstimate est : m_estimates) {
-            double distance = est.pose().minus(m_result)
+            Pose2d robot = RobotObserver.getPose();
+            double distance = est.pose().minus(robot)
                 .getTranslation()
                 .getNorm();
             m_logs.add(
-                new VisionLog(est, distance)
+                new VisionLog(est, distance, robot)
             );
         }
     }
@@ -42,6 +39,7 @@ public class LogBuilder {
     /* a helper record to handle logs */
     public record VisionLog(
         TimestampedPoseEstimate estimate,
-        double error
+        double error,
+        Pose2d robot
     ) {}
 }

--- a/ThriftyTest/src/main/java/frc/robot/vision/SingleInputPoseEstimator.java
+++ b/ThriftyTest/src/main/java/frc/robot/vision/SingleInputPoseEstimator.java
@@ -28,6 +28,7 @@ import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.wpilibj.RobotController;
+import edu.wpi.first.wpilibj.Timer;
 import frc.robot.RobotObserver;
 import frc.robot.Constants.FieldConstants;
 import frc.robot.Constants.VisionConstants;
@@ -105,7 +106,7 @@ public class SingleInputPoseEstimator implements Runnable {
         /* take many */
         for (PhotonPipelineResult result : results) {
             m_logger.debug("photon time: {}", result.getTimestampSeconds());
-            m_logger.debug("fpga time:   {}", RobotController.getMeasureTime().in(Seconds));
+            m_logger.debug("fpga time:   {}", Timer.getFPGATimestamp());
             m_logger.debug("ctre time:   {}", Utils.getCurrentTimeSeconds());
             handleResult(result);
         }
@@ -152,7 +153,7 @@ public class SingleInputPoseEstimator implements Runnable {
         EstimatedRobotPose estimation
     ) {
         double latency = result.metadata.getLatencyMillis() / 1.0e+3;
-        double timestamp = Utils.getCurrentTimeSeconds() - latency;
+        double timestamp = Timer.getFPGATimestamp() - latency;
         Pose3d pose = estimation.estimatedPose;
         double ambiguity = getAmbiguity(result);
         Matrix<N3, N1> stdDevs = calculateStdDevs(result, latency);

--- a/ThriftyTest/src/main/java/frc/robot/vision/VisionHandler.java
+++ b/ThriftyTest/src/main/java/frc/robot/vision/VisionHandler.java
@@ -122,7 +122,6 @@ public class VisionHandler implements AutoCloseable {
         Pose2d currPose = m_drivetrain.getPose();
         m_visionSim.update(currPose);
         // finish logging
-        m_logBuilder.setResult(currPose);
         m_logBuilder.log();
     }
 

--- a/visionlogtool.sh
+++ b/visionlogtool.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# A "helpful" shell utility to extract log files from the RIO
+
+DOWNLOAD_PATH=~/extracted_`date +%Y-%m-%d_%H-%M`
+
+echo "Saving logs to $DOWNLOAD_PATH"
+
+mkdir -p $DOWNLOAD_PATH
+
+scp lvuser@10.34.14.2:~/logs/* $DOWNLOAD_PATH
+
+# NUKE IT
+# ssh -c "rm ~/logs/*" lvuser@10.34.14.2


### PR DESCRIPTION
The phoenix docs changed, so we shifted from
`Utils.getCurrentTimeSeconds()`, but rather now we use `Timer.getFPGATimestamp()`

This seems in more reasonable in sim.

Also, we added a utility shell script to the repo base that has the ability to extract (and then remove) log files from the roborio - including vision logs.